### PR TITLE
Could com.xsh:myblog:0.0.1-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,6 @@
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
             <version>RELEASE</version>
-            <exclusions>
-                 <exclusion>
-                   <artifactId>activation</artifactId>
-                   <groupId>javax.activation</groupId>
-                 </exclusion>
-            </exclusions>
         </dependency>
         <!--redis-->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,12 @@
             <groupId>com.sun.mail</groupId>
             <artifactId>javax.mail</artifactId>
             <version>RELEASE</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>activation</artifactId>
+                   <groupId>javax.activation</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
         <!--redis-->
         <dependency>
@@ -62,12 +68,6 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.6.2</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.qiniu</groupId>
-            <artifactId>happy-dns-java</artifactId>
-            <version>0.1.4</version>
             <scope>compile</scope>
         </dependency>
         <!--阿里云发送短信服务jar包-->
@@ -101,12 +101,32 @@
             <groupId>org.apache.struts.xwork</groupId>
             <artifactId>xwork-core</artifactId>
             <version>2.3.37</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>asm</artifactId>
+                   <groupId>asm</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>asm-commons</artifactId>
+                   <groupId>asm</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>asm-tree</artifactId>
+                   <groupId>asm</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.alibaba/fastjson -->
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
             <version>1.2.57</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>core</artifactId>
+                   <groupId>net.sf.trove4j</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.atlassian.commonmark</groupId>
@@ -130,6 +150,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>tomcat-juli</artifactId>
+                   <groupId>org.apache.tomcat</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -158,6 +184,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>commons-logging</artifactId>
+                   <groupId>commons-logging</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
 
         <!--test，获取wxfile图片名字-->
@@ -165,6 +197,16 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.1</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>commons-logging</artifactId>
+                   <groupId>commons-logging</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>commons-codec</artifactId>
+                   <groupId>commons-codec</groupId>
+                 </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -186,6 +228,28 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>24.0-jre</version>
+            <exclusions>
+                 <exclusion>
+                   <artifactId>j2objc-annotations</artifactId>
+                   <groupId>com.google.j2objc</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>animal-sniffer-annotations</artifactId>
+                   <groupId>org.codehaus.mojo</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>jsr305</artifactId>
+                   <groupId>com.google.code.findbugs</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>error_prone_annotations</artifactId>
+                   <groupId>com.google.errorprone</groupId>
+                 </exclusion>
+                 <exclusion>
+                   <artifactId>checker-compat-qual</artifactId>
+                   <groupId>org.checkerframework</groupId>
+                 </exclusion>
+             </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/126549527/234173592-17ba71da-8b49-4e11-8721-ab658591bee8.png)
![image](https://user-images.githubusercontent.com/126549527/234162327-ea2c8daf-f137-4db7-9072-db3342961997.png)
![image](https://user-images.githubusercontent.com/126549527/234162409-026ffa57-aac5-4db6-bca1-f8ec8e96dd2a.png)
![image](https://user-images.githubusercontent.com/126549527/234162458-be3470ea-af93-4e19-859e-cd9a8731802b.png)
![image](https://user-images.githubusercontent.com/126549527/234162512-08a183f8-e09b-4945-bc78-2e2bc21e14e6.png)

Hi, I found that **_com.xsh:myblog:0.0.1-SNAPSHOT_**’s pom file introduced **_133_** dependencies. However, among them, **_12_** libraries (**_9%_** have not been used by your project), the redundant dependencies are listed below.

More seriously, **_12_**  redundant libraries have not been maintained by developers for more than **_3_** years (outdated dependencies).

Reduce these unused dependencies can help prevent introducing bugs/vulnerabilities from dependencies with outdated. Meanwhile, it can minimize the project size. To safely remove redundant dependencies, I constructed a complete call graph (resolved most of Java reflection and dynamic binding), and validated that they have not been used by the client code.

This PR **_com.xsh:myblog:0.0.1-SNAPSHOT_** for removing the redundant dependencies have passed the tests.

Best regards

## Redundant dependencies
#### Redundant direct dependencies:
        com.qiniu:happy-dns-java:0.1.4:compile [31 KB]
#### Redundant indirect dependencies:
        net.sf.trove4j:core:3.1.0:compile [2 MB]
        com.google.j2objc:j2objc-annotations:1.1:compile [8 KB]
        asm:asm-commons:3.3:compile [37 KB]
        org.codehaus.mojo:animal-sniffer-annotations:1.14:compile [3 KB]
        commons-codec:commons-codec:1.10:compile [277 KB]
        org.apache.tomcat:tomcat-juli:8.5.20:compile [47 KB]
        asm:asm-tree:3.3:compile [20 KB]
        org.checkerframework:checker-compat-qual:2.0.0:compile [30 KB]
        com.google.errorprone:error_prone_annotations:2.1.3:compile [13 KB]
        asm:asm:3.3:compile [42 KB]
        com.google.code.findbugs:jsr305:1.3.9:compile [32 KB]

## Outdated dependencies
com.qiniu:happy-dns-java:0.1.4 (**_2476_** days without maintenance)
org.checkerframework:checker-compat-qual:2.0.0 (**_2548_** days without maintenance)
asm:asm-commons:3.3 (**_4584_** days without maintenance)
net.sf.trove4j:core:3.1.0 (**_1726_** days without maintenance)
asm:asm-tree:3.3 (**_4584_** days without maintenance)
com.google.j2objc:j2objc-annotations:1.1 (**_2287_** days without maintenance)
asm:asm:3.3 (**_4584_** days without maintenance)
com.google.errorprone:error_prone_annotations:2.1.3 (**_1973_** days without maintenance)
org.apache.tomcat:tomcat-juli:8.5.20 (**_2091_** days without maintenance)
com.google.code.findbugs:jsr305:1.3.9 (**_4991_** days without maintenance)
org.codehaus.mojo:animal-sniffer-annotations:1.14 (**_2980_** days without maintenance)
commons-codec:commons-codec:1.10 (**_3092_** days without maintenance)
